### PR TITLE
Edit in the local branch

### DIFF
--- a/common/cluster.py
+++ b/common/cluster.py
@@ -16,5 +16,5 @@ except Exception:
     compute = AmlCompute(name=cpu_compute_target,
                          size="STANDARD_D2_V2",
                          min_instances=1,
-                         max_instances=4)
+                         max_instances=3)
     ml_client.compute.begin_create_or_update(compute)

--- a/config/parallel-env.yml
+++ b/config/parallel-env.yml
@@ -3,15 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-    #- numpy=1.21.2
   - pip=21.2.4
-    #- scikit-learn=0.24.2
-    #- scipy=1.7.1
-    #- pandas>=1.1,<1.2
-    #- matplotlib=3.5.2
-    #- lightgbm=3.3.3
-  - pdf2image=1.16.2
-  - poppler=22.12.0
+  # - pdf2image=1.16.2
+  # - poppler=22.12.0
+  - pypdf==4.2.0
   - pip:
     - inference-schema[numpy-support]==1.3.0
     - xlrd==2.0.1

--- a/pipeline-parallel/main.py
+++ b/pipeline-parallel/main.py
@@ -7,10 +7,6 @@ import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../')))
 from common.authenticate import ml_client
 
-# # Paths for output to be persisted
-# blob_store_path="azureml://datastores/workspaceblobstore/paths/parallel-pipeline-pdf-images/"
-# ocr_store_path="azureml://datastores/workspaceblobstore/paths/parallel-pipeline-ocr-outputs/"
-
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/pipeline-parallel/pdf_to_image_entry.py
+++ b/pipeline-parallel/pdf_to_image_entry.py
@@ -1,8 +1,7 @@
 """Script to create images from PDF files"""
 import os
 import argparse
-from pdf2image import convert_from_path
-from pathlib import Path
+from pypdf import PdfReader, PdfWriter
 
 
 def init():
@@ -26,12 +25,23 @@ def pdf_to_image(file_path):
     # Get filename and directory name
     file_name = file_path.split('/')[-1:][0]
     file_dir = file_name.replace('.pdf', '')
-    images = convert_from_path(file_path)
-    print(f'For {file_name}, have generated {len(images)} images')
+
     # Create the output path first
     outputPath = OUTPUT_PATH + '/' + str(file_dir) + '/'
     if not os.path.exists(outputPath):
         os.makedirs(outputPath)
-    # Save images to outputpath
-    for j, _ in enumerate(images):
-        images[j].save(outputPath + "page" + str(j) + '.png')
+
+    # Create the pypdf objects
+    reader = PdfReader(open(file_path, 'rb'))
+    num_of_pages = len(reader.pages)
+
+    counter = 0
+    for page_number in range(num_of_pages):
+        writer = PdfWriter()
+        page = reader.pages[page_number]
+        writer.add_page(page)
+        counter += 1
+        with open(outputPath + str(page_number) + '.pdf', 'wb') as output:
+            writer.write(output)
+
+    print(f"Wrote {counter} pages for {num_of_pages}.")

--- a/pipeline-parallel/png_to_ocr_entry.py
+++ b/pipeline-parallel/png_to_ocr_entry.py
@@ -30,7 +30,7 @@ def init():
     # )
     document_analysis_client = DocumentAnalysisClient(
             endpoint='https://westus.api.cognitive.microsoft.com/',
-            credential=AzureKeyCredential('<enter your key>'),
+            credential=AzureKeyCredential('<enter the api key>'),
     )
     print("Pass through init done.")
 


### PR DESCRIPTION
Made changes to leverage the `pypdf` library for splitting the PDF instead of the `pdf2image` library which tends to get choked on larger PDF files (this is called out in their [documentation](https://pypi.org/project/pdf2image/) under Limitations).